### PR TITLE
Setting metadataDir in pabConfig.yaml fixes #59

### DIFF
--- a/coop-pab/resources/pabConfig.yaml
+++ b/coop-pab/resources/pabConfig.yaml
@@ -12,6 +12,9 @@ signingKeyFileDir:  ".wallets"
 -- Directory where the encoded transaction files will be saved
 txFileDir:          ".local-cluster/txs"
 
+-- | Directory name of metadata files
+metadataDir:         ".local-cluster/metadata"
+
 -- Dry run mode will build the tx, but skip the submit step
 dryRun:             false
 logLevel:           debug


### PR DESCRIPTION
DONE
- Reproduced the error as reported in #59,
- Added metadataDir explicitly to the pabConfig.yaml,
- Tried to the Tutorial from scratch and it should work now.

Seems like the new BPI metadata features kicked in and the default metadata setting https://github.com/mlabs-haskell/bot-plutus-interface/blame/a1f1d0ec7112b5ecde5ac31471c1a75b67b9dd9d/src/BotPlutusInterface/Types.hs#L357 tried to create `/metadata`