### PR TITLE
Make grep pattern more wild

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Since we're going to be running some services, it's useful to know which ports
 are used by which processes, for example:
 
 ```sh
-[coop-env ~ coop-tutorial] $ netstat -ntuap | grep LISTEN | grep -E "local-cluster|cardano-node|json-fs-store|coop-pab-cli|coop-publishe"
+[coop-env ~ coop-tutorial] $ netstat -ntuap | grep LISTEN | grep -E "local-cluster|cardano-node|json-*|coop-*"
 ```
 
 #### 1. Preparing the environment


### PR DESCRIPTION
The grep pattern for finding running gPRC services becomes a bit more wild, meaning it coop- and related services are easier to find on different platforms.