### PR TITLE
Added plutus-chain-index, polished the README and the coop-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,6 @@ mkdir $COOP_PAB_DIR
 mkdir $JS_STORE_DIR
 mkdir $COOP_PUBLISHER_DIR
 mkdir $CLUSTER_DIR $CLUSTER_DIR/scripts $CLUSTER_DIR/txs
-
 ```
 
 #### 3. Running a local Cardano network
@@ -264,7 +263,6 @@ Let's first start by preparing and running a local Cardano network using the `lo
 
 ```sh
 export CLUSTER_DIR=.local-cluster WALLETS=.wallets
-mkdir $CLUSTER_DIR $CLUSTER_DIR/scripts $CLUSTER_DIR/txs $WALLETS
 local-cluster --dump-info-json $CLUSTER_DIR/local-cluster-info.json \
  --wallet-dir $WALLETS --num-wallets 10 --utxos 5 \
  --chain-index-port 9084 \
@@ -572,7 +570,7 @@ publish.
 First let's prepare and initialize the service:
 
 ```sh
-export JS_STORE_DIR=.json-fs-store && mkdir $JS_STORE_DIR
+export JS_STORE_DIR=.json-fs-store
 sqlite3 -batch $JS_STORE_DIR/json-store.db ""
 json-fs-store-cli genesis --db $JS_STORE_DIR/json-store.db
 generate-keys $JS_STORE_DIR
@@ -633,7 +631,7 @@ gRPC](coop-proto/fact-statement-store-service.proto) service.
 It's straightforward to run:
 
 ```sh
-export COOP_PUBLISHER_DIR=.coop-publisher-cli && mkdir $COOP_PUBLISHER_DIR
+export COOP_PUBLISHER_DIR=.coop-publisher-cli
 generate-keys $COOP_PUBLISHER_DIR
 coop-publisher-cli publisher-grpc
 ```

--- a/coop-extras/coop-env/build.nix
+++ b/coop-extras/coop-env/build.nix
@@ -1,6 +1,7 @@
 { pkgs
 , cardanoCli
 , cardanoNode
+, chainIndex
 , coopPabCli
 , coopPlutusCli
 , coopPublisherCli
@@ -19,6 +20,7 @@ pkgs.mkShell {
     nodejs
     grpcui
     grpcurl
+    chainIndex
     cardanoCli
     cardanoNode
     coopPabCli
@@ -29,14 +31,21 @@ pkgs.mkShell {
     plutipLocalCluster
   ];
   shellHook = ''
+    echo "Making proto and resources symlinks"
+    rm -f coop-proto
     ln -s ${../../coop-proto} coop-proto
+    rm -f resources
     ln -s ${../../coop-pab/resources} resources
+    echo "Sourcing ${./aux.bash}"
     . ${./aux.bash}
+    echo "Running on-load"
     on-load
-    echo "WARNING: Running COOP services requires having $ export LC_CTYPE=C.UTF-8 LC_ALL=C.UTF-8 LANG=C.UTF-8"
+    # WARN(bladyjoker): Running COOP services requires having $ export LC_CTYPE=C.UTF-8 LC_ALL=C.UTF-8 LANG=C.UTF-8
+    echo "Exporting locale"
     export LC_CTYPE=C.UTF-8
     export LC_ALL=C.UTF-8
     export LANG=C.UTF-8
     export PS1='\[\e[0m\][\[\e[0;1;38;5;142m\]coop-env \[\e[0m\]~ \[\e[0m\]\W\[\e[0m\]] \[\e[0m\]\$ \[\e[0m\]'
+    echo "Done"
   '';
 }

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,6 @@
     iohk-nix.follows = "plutip/iohk-nix";
 
     nixpkgs-fourmolu.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-
   };
   outputs =
     { self
@@ -218,6 +217,7 @@
           inherit coopPabCli coopPlutusCli jsFsStoreCli coopPublisherCli plutusJsonCli;
           cardanoNode = coopPabProj.hsPkgs.cardano-node.components.exes.cardano-node;
           cardanoCli = coopPabProj.hsPkgs.cardano-cli.components.exes.cardano-cli;
+          chainIndex = coopPabProj.hsPkgs.plutus-chain-index.components.exes.plutus-chain-index;
         };
 
         renameAttrs = rnFn: pkgs.lib.attrsets.mapAttrs' (n: value: { name = rnFn n; inherit value; });


### PR DESCRIPTION
```
[coop-env ~ coop-tutorial] $ plutus-chain-index 
Missing: COMMAND

Usage: plutus-chain-index [-l|--log-config LOGGING] [-v|--verbose] 
                          [-c|--config CONFIG] [--socket-path ARG] 
                          [--db-path ARG] [--port ARG] [--network-id ARG] 
                          [--append-transaction-queue-size ARG] COMMAND

  Start the chain index process and connect to the node
```