### PR TITLE
Include currency symbols and validator addresses with the deployment config

### DIFF
--- a/coop-hs-types/src/Coop/Types.hs
+++ b/coop-hs-types/src/Coop/Types.hs
@@ -60,12 +60,16 @@ data CoopPlutus = CoopPlutus
 
 -- | COOP deployment (per oracle)
 data CoopDeployment = CoopDeployment
-  { cd'coopAc :: AssetClass
+  { cd'coopAsset :: AssetClass
   -- ^ $COOP one-shot token denoting the COOP deployment
-  , cd'fsMp :: MintingPolicy
+  , cd'fsPolicy :: MintingPolicy
   -- ^ Deployed COOP Fact Statement minting policy
-  , cd'fsV :: Validator
+  , cd'fsSymbol :: CurrencySymbol
+  -- ^ Deployed COOP $FS currency symbol (policy id)
+  , cd'fsValidator :: Validator
   -- ^ Deployed COOP Fact Statement validator
+  , cd'fsAddress :: Address
+  -- ^ Deployed COOP Fact Statement validator address
   , cd'auth :: AuthDeployment
   -- ^ Deployed COOP authentication deployment
   }
@@ -137,14 +141,20 @@ data FsMpRedeemer = FsMpBurn | FsMpMint
 
 -- | COOP Authentication deployment
 data AuthDeployment = AuthDeployment
-  { ad'authorityAc :: AssetClass
+  { ad'authorityAsset :: AssetClass
   -- ^ Authentication authority asset class $AA that can authorize minting $AUTH and $CERT tokens
-  , ad'certV :: Validator
+  , ad'certValidator :: Validator
   -- ^ @CertV Certificate validator holding $CERTs and CertDatums
-  , ad'certMp :: MintingPolicy
+  , ad'certAddress :: Address
+  -- ^ @CertV Certificate validator address
+  , ad'certPolicy :: MintingPolicy
   -- ^ Minting policy for $CERT tokens
-  , ad'authMp :: MintingPolicy
-  -- ^ Minting policy ofr $AUTH tokens
+  , ad'certSymbol :: CurrencySymbol
+  -- ^ Currency symbol (policy id) for $CERT tokens
+  , ad'authPolicy :: MintingPolicy
+  -- ^ Minting policy for $AUTH tokens
+  , ad'authSymbol :: CurrencySymbol
+  -- ^ Currency symbol (policy id) for $AUTH tokens
   }
   deriving stock (Show, Generic, Eq)
   deriving anyclass (ToJSON, FromJSON)

--- a/coop-pab/src/Coop/Pab.hs
+++ b/coop-pab/src/Coop/Pab.hs
@@ -103,7 +103,7 @@ deployCoop coopPlutus aaWallet atLeastAaQ aaQToMint = do
 mkAuthDeployment :: CoopPlutus -> AssetClass -> Integer -> AuthDeployment
 mkAuthDeployment coopPlutus aaAc atLeastAaQ =
   let authMpParams = AuthMpParams aaAc atLeastAaQ
-      certMpParams = CertMpParams aaAc atLeastAaQ (mkValidatorAddress certV)
+      certMpParams = CertMpParams aaAc atLeastAaQ certAddr
       certV = Validator $ cp'certV coopPlutus
       certAddr = mkValidatorAddress certV
       certMp = MintingPolicy $ applyArguments (cp'mkCertMp coopPlutus) [toData certMpParams]

--- a/coop-pab/src/Coop/Pab/Aux.hs
+++ b/coop-pab/src/Coop/Pab/Aux.hs
@@ -43,7 +43,7 @@ import Control.Applicative ((<|>))
 import Control.Concurrent.STM (newTVarIO)
 import Control.Lens ((^.), (^?))
 import Control.Monad (filterM)
-import Coop.Types (AuthDeployment (ad'certPolicy, ad'certValidator), CoopDeployment (cd'auth, cd'fsPolicy, cd'fsValidator), CoopPlutus)
+import Coop.Types (AuthDeployment (ad'authPolicy, ad'authSymbol, ad'certPolicy, ad'certValidator), CoopDeployment (cd'auth, cd'fsSymbol, cd'fsValidator), CoopPlutus)
 import Crypto.Hash (Blake2b_256 (Blake2b_256), hashWith)
 import Data.Aeson (ToJSON, decodeFileStrict)
 import Data.ByteArray (convert)
@@ -183,13 +183,13 @@ deplCertCs :: CoopDeployment -> CurrencySymbol
 deplCertCs = scriptCurrencySymbol . ad'certPolicy . cd'auth
 
 deplAuthCs :: CoopDeployment -> CurrencySymbol
-deplAuthCs = scriptCurrencySymbol . ad'certPolicy . cd'auth
+deplAuthCs = ad'authSymbol . cd'auth
 
 deplAuthMp :: CoopDeployment -> MintingPolicy
-deplAuthMp = ad'certPolicy . cd'auth
+deplAuthMp = ad'authPolicy . cd'auth
 
 deplFsCs :: CoopDeployment -> CurrencySymbol
-deplFsCs = scriptCurrencySymbol . cd'fsPolicy
+deplFsCs = cd'fsSymbol
 
 findOutsAt :: forall a w s. Typeable a => FromData a => Address -> (Value -> Maybe a -> Bool) -> Contract w s Text (Map TxOutRef ChainIndexTxOut)
 findOutsAt addr p = do

--- a/coop-pab/src/Coop/Pab/Aux.hs
+++ b/coop-pab/src/Coop/Pab/Aux.hs
@@ -43,7 +43,7 @@ import Control.Applicative ((<|>))
 import Control.Concurrent.STM (newTVarIO)
 import Control.Lens ((^.), (^?))
 import Control.Monad (filterM)
-import Coop.Types (AuthDeployment (ad'authMp, ad'certMp, ad'certV), CoopDeployment (cd'auth, cd'fsMp, cd'fsV), CoopPlutus)
+import Coop.Types (AuthDeployment (ad'certPolicy, ad'certValidator), CoopDeployment (cd'auth, cd'fsPolicy, cd'fsValidator), CoopPlutus)
 import Crypto.Hash (Blake2b_256 (Blake2b_256), hashWith)
 import Data.Aeson (ToJSON, decodeFileStrict)
 import Data.ByteArray (convert)
@@ -169,27 +169,27 @@ datumFromTxOutOrFail out msg = do
   maybe (throwError msg) return mayDat
 
 deplCertVAddress :: CoopDeployment -> Address
-deplCertVAddress = mkValidatorAddress . ad'certV . cd'auth
+deplCertVAddress = mkValidatorAddress . ad'certValidator . cd'auth
 
 deplFsVAddress :: CoopDeployment -> Address
 deplFsVAddress depl =
-  let fsV = cd'fsV depl in mkValidatorAddress fsV
+  let fsV = cd'fsValidator depl in mkValidatorAddress fsV
 
 deplFsVHash :: CoopDeployment -> ValidatorHash
 deplFsVHash depl =
-  let fsV = cd'fsV depl in validatorHash fsV
+  let fsV = cd'fsValidator depl in validatorHash fsV
 
 deplCertCs :: CoopDeployment -> CurrencySymbol
-deplCertCs = scriptCurrencySymbol . ad'certMp . cd'auth
+deplCertCs = scriptCurrencySymbol . ad'certPolicy . cd'auth
 
 deplAuthCs :: CoopDeployment -> CurrencySymbol
-deplAuthCs = scriptCurrencySymbol . ad'authMp . cd'auth
+deplAuthCs = scriptCurrencySymbol . ad'certPolicy . cd'auth
 
 deplAuthMp :: CoopDeployment -> MintingPolicy
-deplAuthMp = ad'authMp . cd'auth
+deplAuthMp = ad'certPolicy . cd'auth
 
 deplFsCs :: CoopDeployment -> CurrencySymbol
-deplFsCs = scriptCurrencySymbol . cd'fsMp
+deplFsCs = scriptCurrencySymbol . cd'fsPolicy
 
 findOutsAt :: forall a w s. Typeable a => FromData a => Address -> (Value -> Maybe a -> Bool) -> Contract w s Text (Map TxOutRef ChainIndexTxOut)
 findOutsAt addr p = do

--- a/coop-pab/test/Main.hs
+++ b/coop-pab/test/Main.hs
@@ -10,7 +10,7 @@ import Control.Monad (void)
 import Control.Monad.Reader (ReaderT)
 import Coop.Pab (burnAuths, burnCerts, deployCoop, findOutsAtCertVWithCERT, findOutsAtHoldingAa, mintAuthAndCert, mintCertRedeemers, mkMintAuthTrx, mkMintCertTrx, runGcFsTx, runMintFsTx, runRedistributeAuthsTrx)
 import Coop.Pab.Aux (DeployMode (DEPLOY_DEBUG), ciValueOf, datumFromTxOut, deplFsCs, deplFsVAddress, findOutsAt', findOutsAtHolding, findOutsAtHolding', findOutsAtHoldingCurrency, interval', loadCoopPlutus, mkMintOneShotTrx, submitTrx)
-import Coop.Types (AuthDeployment (ad'authorityAc, ad'certV), CoopDeployment (cd'auth, cd'coopAc), CoopPlutus (cp'mkOneShotMp), FsDatum)
+import Coop.Types (AuthDeployment (ad'authorityAsset, ad'certValidator), CoopDeployment (cd'auth, cd'coopAsset), CoopPlutus (cp'mkOneShotMp), FsDatum)
 import Data.ByteString (ByteString)
 import Data.Default (def)
 import Data.Foldable (Foldable (toList))
@@ -81,8 +81,8 @@ tests coopPlutus =
                   logInfo @String "Running as godWallet"
                   self <- ownFirstPaymentPubKeyHash
                   coopDeployment <- deployCoop coopPlutus aaWallet 3 6
-                  let aaAc = ad'authorityAc . cd'auth $ coopDeployment
-                      coopAc = cd'coopAc coopDeployment
+                  let aaAc = ad'authorityAsset . cd'auth $ coopDeployment
+                      coopAc = cd'coopAsset coopDeployment
                   aaOuts <- findOutsAtHolding' aaWallet aaAc
                   coopOuts <- findOutsAtHolding' self coopAc
                   return $
@@ -110,7 +110,7 @@ tests coopPlutus =
                     let validityInterval = interval now (now + 100_000)
                         (mintCertTrx, certAc) = mkMintCertTrx coopDeployment self certRdmrAc validityInterval aaOuts
                     void $ submitTrx @Void mintCertTrx
-                    certOuts <- findOutsAtHolding (mkValidatorAddress . ad'certV . cd'auth $ coopDeployment) certAc
+                    certOuts <- findOutsAtHolding (mkValidatorAddress . ad'certValidator . cd'auth $ coopDeployment) certAc
                     return [ciValueOf certAc out | out <- toList certOuts]
                 )
           )


### PR DESCRIPTION
DONE:
- Changed the field naming a bit to make it more descriptive.
- Added the validator address along with each validator.
- Added the currency symbol along with each minting policy.

## Naming

`cd` - COOP Deployment
`ad` - Auth Deployment
`policy` - the script of a minting policy
`validator` - the script of a validator
`symbol` - the currency symbol of a minting policy (its hash)
`address` - the validator address (its hash)